### PR TITLE
Fix gnatsd tests with incorrect casing

### DIFF
--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/go-nats"
+	nats "github.com/nats-io/go-nats"
 )
 
 // Ensure Reload returns an error when attempting to reload a server that did
@@ -1006,7 +1006,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 	// authorized.
 	select {
 	case err := <-asyncErr:
-		if !strings.Contains(err.Error(), "permissions violation for subscription to \"_inbox.>\"") {
+		if !strings.Contains(strings.ToLower(err.Error()), "permissions violation for subscription to \"_inbox.>\"") {
 			t.Fatalf("Expected permissions violation error, got %v", err)
 		}
 	case <-time.After(5 * time.Second):
@@ -1026,7 +1026,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 
 	select {
 	case err := <-asyncErr:
-		if !strings.Contains(err.Error(), "permissions violation for publish to \"req.foo\"") {
+		if !strings.Contains(strings.ToLower(err.Error()), "permissions violation for publish to \"req.foo\"") {
 			t.Fatalf("Expected permissions violation error, got %v", err)
 		}
 	case <-time.After(5 * time.Second):

--- a/test/certificate_authorization_test.go
+++ b/test/certificate_authorization_test.go
@@ -12,7 +12,7 @@ import (
 
 	"regexp"
 
-	"github.com/nats-io/go-nats"
+	nats "github.com/nats-io/go-nats"
 )
 
 func TestNonTLSConnectionsWithMutualTLSServer(t *testing.T) {
@@ -191,8 +191,8 @@ func TestTLSConnections_CertificateAuthorizationEnable_CertificateCommonNameStar
 	}
 
 	expectedErrorMessage := "nats: authorization violation"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		stackFatalf(t, "Expected '%s' to contain '%s'",  err.Error(), expectedErrorMessage)
+	if !strings.Contains(strings.ToLower(err.Error()), expectedErrorMessage) {
+		stackFatalf(t, "Expected '%s' to contain '%s'", err.Error(), expectedErrorMessage)
 	}
 }
 
@@ -238,8 +238,8 @@ func TestTLSConnections_CertificateAuthorizationEnable_ClientCertificateNoCommon
 	}
 
 	expectedErrorMessage := "nats: authorization violation"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		stackFatalf(t, "Expected '%s' to contain '%s'",  err.Error(), expectedErrorMessage)
+	if !strings.Contains(strings.ToLower(err.Error()), expectedErrorMessage) {
+		stackFatalf(t, "Expected '%s' to contain '%s'", err.Error(), expectedErrorMessage)
 	}
 }
 
@@ -285,8 +285,8 @@ func TestTLSConnections_CertificateAuthorizationEnable_ClientCertificateNonExist
 	}
 
 	expectedErrorMessage := "nats: authorization violation"
-	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		stackFatalf(t, "Expected '%s' to contain '%s'",  err.Error(), expectedErrorMessage)
+	if !strings.Contains(strings.ToLower(err.Error()), expectedErrorMessage) {
+		stackFatalf(t, "Expected '%s' to contain '%s'", err.Error(), expectedErrorMessage)
 	}
 }
 
@@ -340,7 +340,7 @@ func TestTLSConnections_CertificateAuthorizationEnable_CertificateClientUnauthor
 	}
 
 	expectedSuffix := fmt.Sprintf(`permissions violation for subscription to "%s"`, subj)
-	if !strings.HasSuffix(err.Error(), expectedSuffix) {
+	if !strings.HasSuffix(strings.ToLower(err.Error()), expectedSuffix) {
 		stackFatalf(t, "Response did not match expected: \n\tReceived:'%q'\n\tExpected to contain:'%s'\n", err.Error(), expectedSuffix)
 	}
 }
@@ -395,7 +395,7 @@ func TestTLSConnections_CertificateAuthorizationEnable_CertificateClientUnauthor
 	}
 
 	expectedSuffix := fmt.Sprintf(`permissions violation for subscription to "%s"`, subj)
-	if !strings.HasSuffix(err.Error(), expectedSuffix) {
+	if !strings.HasSuffix(strings.ToLower(err.Error()), expectedSuffix) {
 		stackFatalf(t, "Response did not match expected: \n\tReceived:'%q'\n\tExpected to contain:'%s'\n", err.Error(), expectedSuffix)
 	}
 }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/go-nats"
+	nats "github.com/nats-io/go-nats"
 )
 
 func TestTLSConnection(t *testing.T) {
@@ -282,8 +282,8 @@ func TestTLSBadAuthError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error trying to connect to secure server")
 	}
-	if err.Error() != nats.ErrAuthorization.Error() {
-		t.Fatalf("Excpected and auth violation, got %v\n", err)
+	if !strings.Contains(err.Error(), "Authorization Violation") {
+		t.Fatalf("Expected an Authorization Violation, got %v\n", err)
 	}
 }
 


### PR DESCRIPTION
We've experienced some build failures because of some changes in the casing of error messages. This PR fixes that.

[#162655163](https://www.pivotaltracker.com/story/show/162655163)

Co-authored-by: Josh Russett <jrussett@pivotal.io>